### PR TITLE
Fix date.

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   callflow
 author Bojidar Marinov
 email  bojidar.marinov.bg@gmail.com
-date   2015-12-23
+date   2017-10-17
 name   Callflow Diagrams
 desc   Makes callflow diagrams. For an editor see:TODO
 url    https://www.dokuwiki.org/plugin:callflow


### PR DESCRIPTION
A wrong date in `plugin.info.txt` makes it appear as if the plugin is out of date, so the dokuwiki plugin manager constantly suggests to update it.

Thanks for the plugin.